### PR TITLE
Fix: ret auth-konfiguration og middleware-rækkefølge

### DIFF
--- a/Danplanner/Danplanner.Client/Program.cs
+++ b/Danplanner/Danplanner.Client/Program.cs
@@ -123,7 +123,11 @@ builder.Services.AddAuthorization(options =>
 });
 
 builder.Services
-    .AddAuthentication()
+    .AddAuthentication("Cookies")
+    .AddCookie("Cookies", options =>
+    {
+        options.LoginPath = "/Login";
+    })
     .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(
         ApiKeyAuthenticationHandler.SchemeName, null);
 
@@ -147,15 +151,8 @@ builder.Services.AddScoped<IParseDate, ParseDateService>();
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<IReservationLockService, ReservationLockService>();
 
-// HttpClient 
+// HttpClient
 builder.Services.AddHttpClient();
-
-// Cookies
-builder.Services.AddAuthentication("Cookies")
-    .AddCookie("Cookies", options =>
-    {
-        options.LoginPath = "/Login";
-    });
 builder.Services.AddAuthorization(options =>
 {
     options.AddPolicy("AdminOnly", policy =>
@@ -173,9 +170,6 @@ if (!app.Environment.IsDevelopment())
 }
 
 app.UseRateLimiter();
-app.UseAuthentication();
-app.UseAuthorization();
-
 app.UseHttpsRedirection();
 app.UseStaticFiles();
 


### PR DESCRIPTION
- Kombinér de to AddAuthentication-kald til ét for at undgå at Cookies overskriver ApiKey-skemaets default challenge-skema (årsag til 400 på /api/user/user)
- Fjern duplikerede UseAuthentication/UseAuthorization-kald
- Ret middleware-rækkefølge: UseRouting skal stå før UseAuthentication/UseAuthorization