### PR TITLE
Fix: tilføj HandleChallengeAsync til ApiKeyAuthenticationHandler

### DIFF
--- a/Danplanner/Danplanner.Infrastructure/Services/ApiKeyAuthenticationHandler.cs
+++ b/Danplanner/Danplanner.Infrastructure/Services/ApiKeyAuthenticationHandler.cs
@@ -33,14 +33,19 @@ namespace Danplanner.Infrastructure.Services
             {
                 return Task.FromResult(AuthenticateResult.Fail("Invalid API key"));
             }
-            
+
             var identity = new ClaimsIdentity(
                 [new Claim(ClaimTypes.Name, SchemeName)], SchemeName
             );
 
             return Task.FromResult(AuthenticateResult.Success(
                 new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+        }
 
+        protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+        {
+            Response.StatusCode = 401;
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
Uden denne override delegerede ASP.NET Core challenge til default-skemaet (Cookies), som forsøgte redirect til /Login og returnerede 400 for API-endpoints. Med overriden returneres altid 401 ved manglende eller ugyldig API-nøgle.