### PR TITLE
Fix: gør rate limiter IP-baseret i stedet for global

### DIFF
--- a/Danplanner/Danplanner.Client/Program.cs
+++ b/Danplanner/Danplanner.Client/Program.cs
@@ -134,13 +134,16 @@ builder.Services
 // Rate limiter
 builder.Services.AddRateLimiter(options =>
 {
-    options.AddFixedWindowLimiter("fixed", opt =>
-    {
-        opt.PermitLimit = 10;
-        opt.Window = TimeSpan.FromMinutes(1);
-        opt.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-        opt.QueueLimit = 0;
-    });
+    options.AddPolicy("fixed", httpContext =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                Window = TimeSpan.FromMinutes(1),
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0
+            }));
 });
 
 // Confirmation builders


### PR DESCRIPTION
## Hvad er ændret

Rate limiteren i `Program.cs` er ændret fra en global shared tæller til en IP-baseret partitioneret limiter.

**Før:** `AddFixedWindowLimiter` — én fælles tæller for alle brugere. En enkelt bruger kunne lave 10 requests og dermed blokere alle andre for resten af det pågældende minut.

**Efter:** `AddPolicy` med `RateLimitPartition.GetFixedWindowLimiter` — hver IP-adresse får sin egen uafhængige tæller (10 requests/minut).

## Hvorfor

Den gamle implementation udgjorde reelt en selvlavet denial-of-service risiko og gav ingen reel beskyttelse per angriber. IP-baseret limiting er den korrekte tilgang for at begrænse misbrug uden at påvirke legitime brugere.

## Reviewer notes

- Grænsen er stadig 10 requests/minut — kun partitioneringsstrategien er ændret
- `[EnableRateLimiting("fixed")]` på `AuthController` er uændret
- `System.Threading.RateLimiting` var allerede importeret

🤖 Generated with [Claude Code](https://claude.com/claude-code)